### PR TITLE
replace 'GetConfig/SendConfig' commands with 'GetDeviceConfig/GetRunConfig' equivalents

### DIFF
--- a/ReceiveSQL.h
+++ b/ReceiveSQL.h
@@ -387,7 +387,8 @@ class ReceiveSQL{
 	}
 
 	// implementations of WriteMessageToQuery for different message kinds
-	bool WriteConfigToQuery(const std::string& message, BStore& config, std::string& db_out, std::string& sql_out);
+	bool WriteRunConfigToQuery(const std::string& message, BStore& config, std::string& db_out, std::string& sql_out);
+	bool WriteDeviceConfigToQuery(const std::string& message, BStore& config, std::string& db_out, std::string& sql_out);
 	bool WriteCalibrationToQuery(const std::string& message, BStore& calibration, std::string& db_out, std::string& sql_out);
 	bool WriteAlarmToQuery(const std::string& message, BStore& alarm, std::string& db_out, std::string& sql_out);
 	bool WriteRootPlotToQuery(const std::string& message, BStore& plot, std::string& db_out, std::string& sql_out);
@@ -395,7 +396,8 @@ class ReceiveSQL{
 
 	// implementations of ReadMessageToQuery for different message kinds
 	bool ReadQueryToQuery(const std::string& message, BStore& request, std::string& db_out, std::string& sql_out);
-	bool ReadConfigToQuery(const std::string& message, BStore& request, std::string& db_out, std::string& sql_out);
+	bool ReadDeviceConfigToQuery(const std::string& message, BStore& request, std::string& db_out, std::string& sql_out);
+	bool ReadRunConfigToQuery(const std::string& message, BStore& request, std::string& db_out, std::string& sql_out);
 	bool ReadCalibrationToQuery(const std::string& message, BStore& request, std::string& db_out, std::string& sql_out);
 	bool ReadRootPlotToQuery(const std::string& message, BStore& request, std::string& db_out, std::string& sql_out);
 	bool ReadPlotToQuery(const std::string& message, BStore& request, std::string& db_out, std::string& sql_out);

--- a/ServiceDiscoveryConfig
+++ b/ServiceDiscoveryConfig
@@ -1,0 +1,4 @@
+broadcast_address 239.192.1.1
+broadcast_port 5000
+broadcast_period 5    # seconds
+kick_secs 30


### PR DESCRIPTION
replace 'GetConfig/SendConfig' commands with 'GetDeviceConfig/GetRunConfig' equivalents.
Make queries that use version number (for GetDeviceConfig or GetRunConfig when using name+version), return the version number as well as the configuration. This is so that a requestor using '-1' as a proxy for 'the latest version' can know the version number being returned.
change QueryAsJsons to return row as legit JSON, not all quoted strings.