### PR TITLE
Replace generic plots with Plotly specific plots

### DIFF
--- a/JsonParser.h
+++ b/JsonParser.h
@@ -17,6 +17,9 @@ struct JsonParserResult {
 	std::vector<std::string> thenulls{};
 	std::vector<BStore> thestores{};
 	JsonParserResultType type=JsonParserResultType::undefined;
+	bool typechecking;
+	
+	JsonParserResult(bool typechecking): typechecking(typechecking) {};
 };
 
 class JSONP {
@@ -34,7 +37,6 @@ class JSONP {
 	bool ScanJsonObjectPrimitive(std::string thejson, BStore& outstore);
 	bool ScanJsonObject(std::string thejson, BStore& outstore);
 	int verbose=0;
-	bool typechecking=false;
 	
 };
 #endif

--- a/ReceiveSQL.h
+++ b/ReceiveSQL.h
@@ -392,7 +392,7 @@ class ReceiveSQL{
 	bool WriteCalibrationToQuery(const std::string& message, BStore& calibration, std::string& db_out, std::string& sql_out);
 	bool WriteAlarmToQuery(const std::string& message, BStore& alarm, std::string& db_out, std::string& sql_out);
 	bool WriteRootPlotToQuery(const std::string& message, BStore& plot, std::string& db_out, std::string& sql_out);
-	bool WritePlotToQuery(const std::string& message, BStore& plot, std::string& db_out, std::string& sql_out);
+	bool WritePlotlyPlotToQuery(const std::string& message, BStore& plot, std::string& db_out, std::string& sql_out);
 
 	// implementations of ReadMessageToQuery for different message kinds
 	bool ReadQueryToQuery(const std::string& message, BStore& request, std::string& db_out, std::string& sql_out);
@@ -400,7 +400,7 @@ class ReceiveSQL{
 	bool ReadRunConfigToQuery(const std::string& message, BStore& request, std::string& db_out, std::string& sql_out);
 	bool ReadCalibrationToQuery(const std::string& message, BStore& request, std::string& db_out, std::string& sql_out);
 	bool ReadRootPlotToQuery(const std::string& message, BStore& request, std::string& db_out, std::string& sql_out);
-	bool ReadPlotToQuery(const std::string& message, BStore& request, std::string& db_out, std::string& sql_out);
+	bool ReadPlotlyPlotToQuery(const std::string& message, BStore& request, std::string& db_out, std::string& sql_out);
 };
 
 #endif


### PR DESCRIPTION
Support type checking in BStore.

Instead of storing a generic plot in the database, store two JSON objects --- trace and layout --- that are arguments to Plotly plotting functions.