### PR TITLE
Parser updates

### DIFF
--- a/JsonParser.cpp
+++ b/JsonParser.cpp
@@ -41,6 +41,11 @@ bool JSONP::iEquals(const std::string& str1, const std::string& str2){
 	return true;
 }
 
+bool JSONP::IsInteger(std::string& tmp){
+	for(char& next : tmp) if(!std::isdigit(next) && !std::isspace(next) && next!='-') return false;
+	return true;
+}
+
 
 bool JSONP::Parse(std::string thejson, BStore& output){
 
@@ -384,12 +389,15 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 				size_t startpos=0;
 				size_t endpos=0;
 				while(startpos<tmp.length() && std::isspace(tmp[startpos])) ++startpos;
-				if(tmp.front()=='-'){
+				if(false && tmp.front()=='-'){  // always use uint64_t
 					throw std::invalid_argument("not unsigned");
 				} else {
 					// else try to scan into uint64_t
-					uint64_t nextint = std::stoull(tmp,&endpos);
-					if(endpos!=tmp.length()) throw std::invalid_argument("extra chars");
+					//uint64_t nextint = std::stoull(tmp,&endpos);
+					//if(endpos!=tmp.length()) throw std::invalid_argument("extra chars");
+					
+					if(!IsInteger(tmp)){ throw std::invalid_argument("not integer"); }
+					uint64_t nextint = strtoull(tmp.c_str(),nullptr,10); // use old version to ignore out of range errors
 					if(verbose) std::cout<<"match uint"<<std::endl;
 					theuints.push_back(nextint);
 					continue;
@@ -603,7 +611,7 @@ bool JSONP::ScanJsonPrimitive(std::string thejson, std::string thekey, BStore& o
 		size_t startpos=0;
 		size_t endpos=0;
 		while(startpos<thejson.length() && std::isspace(thejson[startpos])) ++startpos;
-		if(thejson.front()=='-'){
+		if(false && thejson.front()=='-'){ // always use uint64_t
 			// if negative use temporary int64_t
 			int64_t nextint = std::stoll(thejson,&endpos);
 			if(endpos!=thejson.length()) throw std::invalid_argument("extra chars");
@@ -611,8 +619,11 @@ bool JSONP::ScanJsonPrimitive(std::string thejson, std::string thekey, BStore& o
 			return true;
 		} else {
 			// else use temporary uint64_t
-			uint64_t nextint = std::stoull(thejson,&endpos);
-			if(endpos!=thejson.length()) throw std::invalid_argument("extra chars");
+			//uint64_t nextint = std::stoull(thejson,&endpos);
+			//if(endpos!=thejson.length()) throw std::invalid_argument("extra chars");
+			
+			if(!IsInteger(thejson)){ throw std::invalid_argument("not integer"); }
+			uint64_t nextint = strtoull(thejson.c_str(),nullptr,10); // use old version to ignore out of range errors
 			outstore.Set(thekey,nextint);
 			return true;
 		}
@@ -847,15 +858,18 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 				size_t endpos=0;
 				while(startpos<tmp.length() && std::isspace(tmp[startpos])) ++startpos;
 				try {
-					if(tmp.front()=='-'){
+					if(false && tmp.front()=='-'){ // always use uint64_t
 						// if negative try temporary int64_t
 						int64_t nextint = std::stoll(tmp,&endpos);
 						if(endpos!=tmp.length()) throw std::invalid_argument("extra chars");
 						outstore.Set(next_key,nextint);
 					} else {
 						// else try temporary uint64_t
-						uint64_t nextint = std::stoull(tmp,&endpos);
-						if(endpos!=tmp.length()) throw std::invalid_argument("extra chars");
+						//uint64_t nextint = std::stoull(tmp,&endpos);
+						//if(endpos!=tmp.length()) throw std::invalid_argument("extra chars");
+						
+						if(!IsInteger(tmp)){ throw std::invalid_argument("not integer"); }
+						uint64_t nextint = strtoull(tmp.c_str(),nullptr,10); // use old version to ignore out of range errors
 						outstore.Set(next_key,nextint);
 					}
 					trytoparse=false;

--- a/JsonParser.cpp
+++ b/JsonParser.cpp
@@ -65,12 +65,16 @@ bool JSONP::Parse(std::string thejson, BStore& output){
 	// but we'll need to make up a key: we'll use simple index keys: "0"
 	// (this will also be true for nested arrays)
 	if(thejson.front()=='['){
-		JsonParserResult res(output.TypeChecking());
+		JsonParserResult res;
 		bool ok =  ScanJsonArray(thejson.substr(1,thejson.length()-2), res);
 		if(!ok || res.type==JsonParserResultType::undefined) return false;
 		switch (res.type){
-			case JsonParserResultType::ints: {
-				output.Set("0",res.theints);
+			case JsonParserResultType::sints: {
+				output.Set("0",res.thesints);
+				break;
+			}
+			case JsonParserResultType::uints: {
+				output.Set("0",res.theuints);
 				break;
 			}
 			case JsonParserResultType::floats: {
@@ -125,19 +129,22 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 	// containing ints, floats, strings, bools, nulls or objects,
 	// but they can also be inhomogeneous combining elements of all these different types
 	// try to encapsulate the array in the minimal datatype required
-	std::vector<int64_t>& theints = result.theints;
+	std::vector<int64_t>& thesints = result.thesints;
+	std::vector<uint64_t>& theuints = result.theuints;
 	std::vector<double>& thefloats = result.thefloats;
 	std::vector<std::string>& thestrings = result.thestrings;
 	std::vector<int>& thebools = result.thebools;             // BStore doesn't support vector<bool>
 	std::vector<std::string>& thenulls = result.thenulls;     // BStore doesn't support vector<nullptr_t>
-	std::vector<BStore>& thestores = result.thestores;    // FIXME rather than a vector<BStore>
+	std::vector<BStore>& thestores = result.thestores;        // FIXME rather than a vector<BStore>
+	BStore thestore;
 	// it would be better to use a BStore of BStores, where each element's key is its index TODO
 	// we just need to track the index in case we aren't filling a vector
 	
 	// we'll use a set of flags while parsing to select how we try to
 	// interpret the next element. As each type gets ruled out we'll
 	// skip trying that interpretation for further elements
-	bool all_ints=true;
+	bool all_sints=true;
+	bool all_uints=true;
 	bool all_floats=true;
 	bool all_strings=true;
 	bool all_bools=true;
@@ -149,7 +156,8 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 	if(thejson.find('"')!=std::string::npos){
 		if(verbose) std::cout<<"found quote: can't be ints, floats, bools or nulls"<<std::endl;
 		// not numeric, bool or null
-		all_ints=false;
+		all_sints=false;
+		all_uints=false;
 		all_floats=false;
 		all_bools=false;
 		all_nulls=false;
@@ -163,7 +171,8 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 	// we can also rule out integers, bools and nulls by the presence of a '.' character
 	else if(thejson.find('.')!=std::string::npos){
 		if(verbose) std::cout<<"found full stop: can't be ints, bools or nulls"<<std::endl;
-		all_ints=false;
+		all_sints=false;
+		all_uints=false;
 		all_bools=false;
 		all_nulls=false;
 		// could be floats or strings, or arrays or objects
@@ -171,7 +180,8 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 	// rule out integers by anything other than digits and signs
 	if(thejson.find_first_not_of("01234567890+-, ")!=std::string::npos){
 		if(verbose) std::cout<<"found something other than digits: can't be ints"<<std::endl;
-		all_ints=false;
+		all_sints=false;
+		all_uints=false;
 	}
 	// rule out doubles by anything other than numbers, signs and scientific notation characters
 	if(thejson.find_first_not_of("0123456789+-.Ee^*, ")!=std::string::npos){
@@ -191,7 +201,8 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 	// (otherwise these could potentially just be characters within the strings)
 	if(all_strings==false && thejson.substr(1,thejson.length()-2).find("{}[]:")!=std::string::npos){
 		if(verbose) std::cout<<"can't be strings and has delimiters; must be array or object"<<std::endl;
-		all_ints=false;
+		all_sints=false;
+		all_uints=false;
 		all_floats=false;
 		all_strings=false;
 		all_bools=false;
@@ -265,33 +276,40 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 			// since we can't append an object to that vector, we need to translate those
 			// previosly parsed elements into a new vector<BStores> which is sufficiently
 			// generic to accommodate the new element as well
-			all_ints=false;
+			all_sints=false;
+			all_uints=false;
 			all_floats=false;
 			all_strings=false;
 			all_bools=false;
 			all_nulls=false;
-			if(theints.size()){
-				thestores.resize(theints.size(), BStore(false, result.typechecking));
-				for(int i=0; i<theints.size(); ++i) thestores.at(i).Set("0", theints.at(i));
-				theints.clear();
+			
+			if(thesints.size()){
+				thestores.resize(thesints.size(), BStore(false, false));
+				for(int i=0; i<thesints.size(); ++i) thestores.at(i).Set("0", thesints.at(i));
+				thesints.clear();
+			}
+			if(theuints.size()){
+				thestores.resize(theuints.size(), BStore(false, false));
+				for(int i=0; i<theuints.size(); ++i) thestores.at(i).Set("0", theuints.at(i));
+				theuints.clear();
 			}
 			if(thefloats.size()){
-				thestores.resize(thefloats.size(), BStore(false, result.typechecking));
+				thestores.resize(thefloats.size(), BStore(false, false));
 				for(int i=0; i<thefloats.size(); ++i) thestores.at(i).Set("0", thefloats.at(i));
 				thefloats.clear();
 			}
 			if(thestrings.size()){
-				thestores.resize(thestrings.size(), BStore(false, result.typechecking));
+				thestores.resize(thestrings.size(), BStore(false, false));
 				for(int i=0; i<thestrings.size(); ++i) thestores.at(i).Set("0", thestrings.at(i));
 				thestrings.clear();
 			}
 			if(thebools.size()){
-				thestores.resize(thebools.size(), BStore(false, result.typechecking));
+				thestores.resize(thebools.size(), BStore(false, false));
 				for(int i=0; i<thebools.size(); ++i) thestores.at(i).Set("0", thebools.at(i));
 				thebools.clear();
 			}
 			if(thenulls.size()){
-				thestores.resize(thenulls.size(), BStore(false, result.typechecking));
+				thestores.resize(thenulls.size(), BStore(false, false));
 				std::string emptystring="";
 				for(int i=0; i<thenulls.size(); ++i) thestores.at(i).Set("0", emptystring);
 				thenulls.clear();
@@ -299,20 +317,24 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 		}
 		if(tmp.front()=='{'){
 			// add the new element
-			thestores.resize(thestores.size()+1, BStore(false, result.typechecking));
+			thestores.resize(thestores.size()+1, BStore(false, false));
 			bool ok =  ScanJsonObject(tmp.substr(1,tmp.length()-2), thestores.back());
 			if(!ok) return false;
 			continue;
 		}
 		if(tmp.front()=='['){
 			// add the new element
-			thestores.resize(thestores.size()+1, BStore(false, result.typechecking));
-			JsonParserResult res(result.typechecking);
+			thestores.resize(thestores.size()+1, BStore(false, false));
+			JsonParserResult res;
 			bool ok =  ScanJsonArray(tmp.substr(1,tmp.length()-2), res);
 			if(!ok || res.type==JsonParserResultType::undefined) return false;
 			switch (res.type){
-				case JsonParserResultType::ints: {
-					thestores.back().Set("0",res.theints);
+				case JsonParserResultType::sints: {
+					thestores.back().Set("0",res.thesints);
+					break;
+				}
+				case JsonParserResultType::uints: {
+					thestores.back().Set("0",res.theuints);
 					break;
 				}
 				case JsonParserResultType::floats: {
@@ -349,26 +371,62 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 		}
 		
 		// ok not an object or array, try to handle it as a simpler type
-		if(all_ints){
-			if(verbose) std::cout<<"trying int"<<std::endl;
-			// try to parse as integer, until we find something that fails
+		if(all_uints){
+			if(verbose) std::cout<<"trying unsigned int"<<std::endl;
+			// try to parse as unsigned integer, until we find something that fails
+			try {
+				// discard leading whitespace
+				size_t startpos=0;
+				size_t endpos=0;
+				while(startpos<tmp.length() && std::isspace(tmp[startpos])) ++startpos;
+				if(tmp.front()=='-'){
+					throw std::invalid_argument("not unsigned");
+				} else {
+					// else try to scan into uint64_t
+					uint64_t nextint = std::stoull(tmp,&endpos);
+					if(endpos!=tmp.length()) throw std::invalid_argument("extra chars");
+					if(verbose) std::cout<<"match uint"<<std::endl;
+					theuints.push_back(nextint);
+					continue;
+				}
+			}
+			catch(std::invalid_argument& e){
+				// swap any already parsed integers to the signed integer array
+				if(verbose){ std::cout<<"shifting unsigned ints to signed ints"<<std::endl; }
+				if(theuints.size() && thesints.size()){
+					// sanity check: shouldn't ever happen
+					std::cerr<<"parsing error; transferring unsigned ints into non-empty ints!"<<std::endl;
+					return false;
+				}
+				for(uint64_t& anint : theuints) thesints.push_back(anint);
+				theuints.clear();
+				all_uints = false;
+				all_sints = true;
+			}
+		}
+		if(all_sints){
+			if(verbose) std::cout<<"trying signed int"<<std::endl;
+			// try to parse as signed integer, until we find something that fails
 			try {
 				size_t endpos=0;
-				int64_t nextint = std::stol(tmp,&endpos);
+				int64_t nextint = std::stoll(tmp,&endpos);
 				if(endpos!=tmp.length()) throw std::invalid_argument("extra chars");
-				if(verbose) std::cout<<"match int"<<std::endl;
-				theints.push_back(nextint);
+				if(verbose) std::cout<<"match sint"<<std::endl;
+				thesints.push_back(nextint);
 				continue;
 			}
 			catch(std::invalid_argument& e){
-				all_ints = false;
-				// swap any already parsed integers to the float array
-				if(theints.size() && thefloats.size()){
+				// swap any already parsed integers to the signed integer array
+				if(verbose){ std::cout<<"shifting signed ints to floats"<<std::endl; }
+				if(theuints.size() && thesints.size()){
 					// sanity check: shouldn't ever happen
-					std::cerr<<"parsing error; transferring ints into non-empty floats!"<<std::endl;
+					std::cerr<<"parsing error; transferring signed ints into non-empty floats!"<<std::endl;
 					return false;
 				}
-				for(int64_t& anint : theints) thefloats.push_back(anint);
+				for(int64_t& anint : thesints) thefloats.push_back(anint);
+				thesints.clear();
+				all_sints = false;
+				all_floats = true;
 			}
 		}
 		if(all_floats){
@@ -383,17 +441,21 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 				continue;
 			}
 			catch(std::invalid_argument& e){
-				all_floats = false;
 				// must be inhomogeneous types. transfer to stores
+				// FIXME can't this just be one store? why multiple? FIXME FIXME FIXME
+				if(verbose){ std::cout<<"shifting floats to stores"<<std::endl; }
 				if(thefloats.size() && thestores.size()){
 					// sanity check: shouldn't ever happen
 					std::cerr<<"parsing error; transferring floats into non-empty stores!"<<std::endl;
 					return false;
 				}
-				thestores.resize(thefloats.size(), BStore(false, result.typechecking));
+				thestores.resize(thefloats.size(), BStore(false, false));
 				for(int i=0; i<thefloats.size(); ++i){
 					thestores.at(i).Set("0", thefloats.at(i));
 				}
+				thefloats.clear();
+				all_floats = false;
+				all_stores = true;
 			}
 		}
 		if(all_bools){
@@ -408,17 +470,20 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 				continue;
 			} else {
 				// not all bools
-				all_bools=false;
+				if(verbose){ std::cout<<"shifting bools to stores"<<std::endl; }
 				// transfer current contents to Store
 				if(thebools.size() && thestores.size()){
 					// sanity check: shouldn't ever happen
 					std::cerr<<"parsing error; transferring bools into non-empty stores!"<<std::endl;
 					return false;
 				}
-				thestores.resize(thestores.size(), BStore(false, result.typechecking));
+				thestores.resize(thestores.size(), BStore(false, false));
 				for(int i=0; i<thebools.size(); ++i){
 					thestores.at(i).Set("0", thebools.at(i));
 				}
+				thebools.clear();
+				all_bools = false;
+				all_stores = true;
 			}
 		}
 		if(all_nulls){
@@ -429,18 +494,21 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 				continue;
 			} else {
 				// not all nulls
-				all_nulls=false;
+				if(verbose){ std::cout<<"shifting nulls to stores"<<std::endl; }
 				// transfer current contents to Store
 				if(thenulls.size() && thestores.size()){
 					// sanity check: shouldn't ever happen
 					std::cerr<<"parsing error; transferring nulls into non-empty stores!"<<std::endl;
 					return false;
 				}
-				thestores.resize(thenulls.size(), BStore(false, result.typechecking));
+				thestores.resize(thenulls.size(), BStore(false, false));
 				for(int i=0; i<thenulls.size(); ++i){
 					std::string emptystring="";
 					thestores.at(i).Set(std::to_string(i), emptystring);
 				}
+				thenulls.clear();
+				all_nulls = false;
+				all_stores = true;
 			}
 		}
 		if(all_strings){
@@ -453,17 +521,20 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 				continue;
 			} else {
 				// doesn't look like a json string. need to use stores
-				all_strings=false;
+				if(verbose){ std::cout<<"shifting strings to stores"<<std::endl; }
 				// transfer current contents to Stores
 				if(thestrings.size() && thestores.size()){
 					// sanity check: shouldn't ever happen
 					std::cerr<<"parsing error; transferring nulls into non-empty stores!"<<std::endl;
 					return false;
 				}
-				thestores.resize(thestrings.size(), BStore(false, result.typechecking));
+				thestores.resize(thestrings.size(), BStore(false, false));
 				for(int i=0; i<thestrings.size(); ++i){
 					thestores.at(i).Set("0",thestrings.at(i));
 				}
+				thestrings.clear();
+				all_strings = false;
+				all_stores = true;
 			}
 		}
 		if(all_stores){
@@ -471,7 +542,7 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 			// build a BStore to encapsulate this element,
 			// but note that it's not an object or array, so we're just gonna
 			// have to make a BStore entry of the correct primitive type
-			thestores.resize(thestores.size()+1,BStore(false, result.typechecking));
+			thestores.resize(thestores.size()+1,BStore(false, false));
 			bool ok = ScanJsonObjectPrimitive(tmp, thestores.back());
 			if(verbose) std::cout<<"returned "<<ok<<std::endl;
 			if(!ok) return false;
@@ -485,7 +556,8 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 	
 	// determine the type of our return
 	int typesset=0;
-	if(theints.size())   { result.type = JsonParserResultType::ints;    ++typesset; }
+	if(thesints.size())  { result.type = JsonParserResultType::sints;   ++typesset; }
+	if(theuints.size())  { result.type = JsonParserResultType::uints;   ++typesset; }
 	if(thefloats.size()) { result.type = JsonParserResultType::floats;  ++typesset; }
 	if(thestrings.size()){ result.type = JsonParserResultType::strings; ++typesset; }
 	if(thebools.size())  { result.type = JsonParserResultType::bools;   ++typesset; }
@@ -510,11 +582,24 @@ bool JSONP::ScanJsonObjectPrimitive(std::string thejson, BStore& outstore){
 	
 	try {
 		if(verbose) std::cout<<"try int"<<std::endl;
+
+		// discard leading whitespace
+		size_t startpos=0;
 		size_t endpos=0;
-		int64_t nextint = std::stol(thejson,&endpos);
-		if(endpos!=thejson.length()) throw std::invalid_argument("extra chars");
-		outstore.Set("0",nextint);
-		return true;
+		while(startpos<thejson.length() && std::isspace(thejson[startpos])) ++startpos;
+		if(thejson.front()=='-'){
+			// if negative use temporary int64_t
+			int64_t nextint = std::stoll(thejson,&endpos);
+			if(endpos!=thejson.length()) throw std::invalid_argument("extra chars");
+			outstore.Set("0",nextint);
+			return true;
+		} else {
+			// else use temporary uint64_t
+			uint64_t nextint = std::stoull(thejson,&endpos);
+			if(endpos!=thejson.length()) throw std::invalid_argument("extra chars");
+			outstore.Set("0",nextint);
+			return true;
+		}
 	}
 	catch(std::invalid_argument& e){
 		// not an int
@@ -673,7 +758,7 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 			bool trytoparse=true;
 			if(trytoparse && tmp.front()=='{'){
 				// add the new element
-				BStore res(false, outstore.TypeChecking());
+				BStore res(false, false);
 				bool ok =  ScanJsonObject(tmp.substr(1,tmp.length()-2), res);
 				if(!ok) return false;
 				outstore.Set(next_key,res);
@@ -683,14 +768,19 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 			if(trytoparse && tmp.front()=='['){
 				if(verbose) std::cout<<"it array"<<std::endl;
 				// add the new element
-				JsonParserResult res(outstore.TypeChecking());
+				JsonParserResult res;
 				bool ok =  ScanJsonArray(tmp.substr(1,tmp.length()-2), res);
 				if(verbose) std::cout<<"parse array ret:"<<ok<<std::endl;
 				if(!ok || res.type==JsonParserResultType::undefined) return false;
 				switch (res.type){
-					case JsonParserResultType::ints: {
-						if(verbose) std::cout<<"array was of ints"<<std::endl;
-						outstore.Set(next_key,res.theints);
+					case JsonParserResultType::sints: {
+						if(verbose) std::cout<<"array was of signed ints"<<std::endl;
+						outstore.Set(next_key,res.thesints);
+						break;
+					}
+					case JsonParserResultType::uints: {
+						if(verbose) std::cout<<"array was of unsigned ints"<<std::endl;
+						outstore.Set(next_key,res.theuints);
 						break;
 					}
 					case JsonParserResultType::floats: {
@@ -734,11 +824,22 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 			if(verbose && trytoparse) std::cout<<"not array"<<std::endl;
 			
 			if(trytoparse){
+				// discard leading whitespace
+				size_t startpos=0;
+				size_t endpos=0;
+				while(startpos<tmp.length() && std::isspace(tmp[startpos])) ++startpos;
 				try {
-					size_t endpos=0;
-					int64_t nextint = std::stol(tmp,&endpos);
-					if(endpos!=tmp.length()) throw std::invalid_argument("extra chars");
-					outstore.Set(next_key,nextint);
+					if(tmp.front()=='-'){
+						// if negative use temporary int64_t
+						int64_t nextint = std::stoll(tmp,&endpos);
+						if(endpos!=tmp.length()) throw std::invalid_argument("extra chars");
+						outstore.Set(next_key,nextint);
+					} else {
+						// else use temporary uint64_t
+						uint64_t nextint = std::stoull(tmp,&endpos);
+						if(endpos!=tmp.length()) throw std::invalid_argument("extra chars");
+						outstore.Set(next_key,nextint);
+					}
 					trytoparse=false;
 				}
 				catch(std::invalid_argument& e){
@@ -788,7 +889,7 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 			}
 			if(verbose && trytoparse) std::cout<<"not string"<<std::endl;
 			if(trytoparse){
-				BStore astore(false, outstore.TypeChecking());
+				BStore astore(false, false);
 				bool ok = ScanJsonObjectPrimitive(tmp, astore);
 				if(!ok) return false;
 				outstore.Set(next_key,astore);

--- a/JsonParser.cpp
+++ b/JsonParser.cpp
@@ -45,6 +45,8 @@ bool JSONP::iEquals(const std::string& str1, const std::string& str2){
 bool JSONP::Parse(std::string thejson, BStore& output){
 
 	if(verbose) std::cout<<"parsing '"<<thejson<<"'"<<std::endl;
+	typechecking = output.TypeChecking();
+	
 	// strip leading/trailing whitespace
 	thejson = Trim(thejson);
 	
@@ -61,11 +63,11 @@ bool JSONP::Parse(std::string thejson, BStore& output){
 		return ScanJsonObject(thejson.substr(1,thejson.length()-2), output);
 	}
 	
-	// if array, well, the contents we can make a BStore,
-	// but we'll need to make up a key: we'll use simple index keys: "0"
-	// (this will also be true for nested arrays)
+	// if array, well we're going to return it as a BStore, but a BStore needs a key
+	// so just use "0" i guess....? :/
+	// TODO factor this into a wrapper around ScanJsonArray so that it makes a BStore entry
 	if(thejson.front()=='['){
-		JsonParserResult res;
+		JsonParserResult res(typechecking);
 		bool ok =  ScanJsonArray(thejson.substr(1,thejson.length()-2), res);
 		if(!ok || res.type==JsonParserResultType::undefined) return false;
 		switch (res.type){
@@ -94,7 +96,7 @@ bool JSONP::Parse(std::string thejson, BStore& output){
 				break;
 			}
 			case JsonParserResultType::stores: {
-				output.Set("0",res.thestores);
+				output.Set("0",res.thestore);
 				break;
 			}
 			case JsonParserResultType::empty: {
@@ -135,10 +137,8 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 	std::vector<std::string>& thestrings = result.thestrings;
 	std::vector<int>& thebools = result.thebools;             // BStore doesn't support vector<bool>
 	std::vector<std::string>& thenulls = result.thenulls;     // BStore doesn't support vector<nullptr_t>
-	std::vector<BStore>& thestores = result.thestores;        // FIXME rather than a vector<BStore>
-	BStore thestore;
-	// it would be better to use a BStore of BStores, where each element's key is its index TODO
-	// we just need to track the index in case we aren't filling a vector
+	BStore& thestore = result.thestore;
+	int theindex=0;
 	
 	// we'll use a set of flags while parsing to select how we try to
 	// interpret the next element. As each type gets ruled out we'll
@@ -274,7 +274,7 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 			// since inhomogeneous element types are valid, we could have already parsed
 			// several previous entries and built up e.g. a vector<int64_t>. But now,
 			// since we can't append an object to that vector, we need to translate those
-			// previosly parsed elements into a new vector<BStores> which is sufficiently
+			// previously parsed elements into a new BStore which is sufficiently
 			// generic to accommodate the new element as well
 			all_sints=false;
 			all_uints=false;
@@ -284,82 +284,86 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 			all_nulls=false;
 			
 			if(thesints.size()){
-				thestores.resize(thesints.size(), BStore(false, false));
-				for(int i=0; i<thesints.size(); ++i) thestores.at(i).Set("0", thesints.at(i));
+				for(int i=0; i<thesints.size(); ++i) thestore.Set(std::to_string(i), thesints.at(i));
+				theindex=thesints.size();
 				thesints.clear();
 			}
 			if(theuints.size()){
-				thestores.resize(theuints.size(), BStore(false, false));
-				for(int i=0; i<theuints.size(); ++i) thestores.at(i).Set("0", theuints.at(i));
+				for(int i=0; i<theuints.size(); ++i) thestore.Set(std::to_string(i), theuints.at(i));
+				theindex=theuints.size();
 				theuints.clear();
 			}
 			if(thefloats.size()){
-				thestores.resize(thefloats.size(), BStore(false, false));
-				for(int i=0; i<thefloats.size(); ++i) thestores.at(i).Set("0", thefloats.at(i));
+				for(int i=0; i<thefloats.size(); ++i) thestore.Set(std::to_string(i), thefloats.at(i));
+				theindex=thefloats.size();
 				thefloats.clear();
 			}
 			if(thestrings.size()){
-				thestores.resize(thestrings.size(), BStore(false, false));
-				for(int i=0; i<thestrings.size(); ++i) thestores.at(i).Set("0", thestrings.at(i));
+				for(int i=0; i<thestrings.size(); ++i) thestore.Set(std::to_string(i), thestrings.at(i));
+				theindex=thestrings.size();
 				thestrings.clear();
 			}
 			if(thebools.size()){
-				thestores.resize(thebools.size(), BStore(false, false));
-				for(int i=0; i<thebools.size(); ++i) thestores.at(i).Set("0", thebools.at(i));
+				for(int i=0; i<thebools.size(); ++i) thestore.Set(std::to_string(i), thebools.at(i));
+				theindex=thebools.size();
 				thebools.clear();
 			}
 			if(thenulls.size()){
-				thestores.resize(thenulls.size(), BStore(false, false));
 				std::string emptystring="";
-				for(int i=0; i<thenulls.size(); ++i) thestores.at(i).Set("0", emptystring);
+				for(int i=0; i<thenulls.size(); ++i) thestore.Set(std::to_string(i), emptystring);
+				theindex=thenulls.size();
 				thenulls.clear();
 			}
 		}
 		if(tmp.front()=='{'){
 			// add the new element
-			thestores.resize(thestores.size()+1, BStore(false, false));
-			bool ok =  ScanJsonObject(tmp.substr(1,tmp.length()-2), thestores.back());
+			BStore tmpstore(false,typechecking);
+			bool ok =  ScanJsonObject(tmp.substr(1,tmp.length()-2), tmpstore);
 			if(!ok) return false;
+			thestore.Set(std::to_string(theindex),tmpstore);
+			++theindex;
 			continue;
 		}
 		if(tmp.front()=='['){
 			// add the new element
-			thestores.resize(thestores.size()+1, BStore(false, false));
-			JsonParserResult res;
+			if(verbose) std::cout<<"element is array"<<std::endl;
+			JsonParserResult res(typechecking);
+			BStore tmpstore(false,typechecking);
+			std::string tmpkey = std::to_string(theindex);
 			bool ok =  ScanJsonArray(tmp.substr(1,tmp.length()-2), res);
 			if(!ok || res.type==JsonParserResultType::undefined) return false;
 			switch (res.type){
 				case JsonParserResultType::sints: {
-					thestores.back().Set("0",res.thesints);
+					thestore.Set(tmpkey,res.thesints);
 					break;
 				}
 				case JsonParserResultType::uints: {
-					thestores.back().Set("0",res.theuints);
+					thestore.Set(tmpkey,res.theuints);
 					break;
 				}
 				case JsonParserResultType::floats: {
-					thestores.back().Set("0",res.thefloats);
+					thestore.Set(tmpkey,res.thefloats);
 					break;
 				}
 				case JsonParserResultType::strings: {
-					thestores.back().Set("0",res.thestrings);
+					thestore.Set(tmpkey,res.thestrings);
 					break;
 				}
 				case JsonParserResultType::bools: {
-					thestores.back().Set("0",res.thebools);
+					thestore.Set(tmpkey,res.thebools);
 					break;
 				}
 				case JsonParserResultType::nulls: {
-					thestores.back().Set("0",res.thenulls);
+					thestore.Set(tmpkey,res.thenulls);
 					break;
 				}
 				case JsonParserResultType::stores: {
-					thestores.back().Set("0",res.thestores);
+					thestore.Set(tmpkey,res.thestore);
 					break;
 				}
 				case JsonParserResultType::empty: {
-					std::vector<std::string> emptyvec{};
-					thestores.back().Set("0",emptyvec);
+					std::vector<std::string> emptyvec;
+					thestore.Set(tmpkey,emptyvec);
 					break;
 				}
 				default:{
@@ -367,6 +371,7 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 					return false;
 				}
 			}
+			++theindex;
 			continue;
 		}
 		
@@ -441,18 +446,17 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 				continue;
 			}
 			catch(std::invalid_argument& e){
-				// must be inhomogeneous types. transfer to stores
-				// FIXME can't this just be one store? why multiple? FIXME FIXME FIXME
-				if(verbose){ std::cout<<"shifting floats to stores"<<std::endl; }
-				if(thefloats.size() && thestores.size()){
+				// must be inhomogeneous types. transfer to store
+				if(verbose){ std::cout<<"shifting floats to store"<<std::endl; }
+				if(thefloats.size() && theindex>0){
 					// sanity check: shouldn't ever happen
-					std::cerr<<"parsing error; transferring floats into non-empty stores!"<<std::endl;
+					std::cerr<<"parsing error; transferring floats into non-empty store!"<<std::endl;
 					return false;
 				}
-				thestores.resize(thefloats.size(), BStore(false, false));
 				for(int i=0; i<thefloats.size(); ++i){
-					thestores.at(i).Set("0", thefloats.at(i));
+					thestore.Set(std::to_string(i), thefloats.at(i));
 				}
+				theindex=thefloats.size();
 				thefloats.clear();
 				all_floats = false;
 				all_stores = true;
@@ -472,15 +476,15 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 				// not all bools
 				if(verbose){ std::cout<<"shifting bools to stores"<<std::endl; }
 				// transfer current contents to Store
-				if(thebools.size() && thestores.size()){
+				if(thebools.size() && theindex>0){
 					// sanity check: shouldn't ever happen
-					std::cerr<<"parsing error; transferring bools into non-empty stores!"<<std::endl;
+					std::cerr<<"parsing error; transferring bools into non-empty store!"<<std::endl;
 					return false;
 				}
-				thestores.resize(thestores.size(), BStore(false, false));
 				for(int i=0; i<thebools.size(); ++i){
-					thestores.at(i).Set("0", thebools.at(i));
+					thestore.Set(std::to_string(i), thebools.at(i));
 				}
+				theindex = thebools.size();
 				thebools.clear();
 				all_bools = false;
 				all_stores = true;
@@ -496,16 +500,16 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 				// not all nulls
 				if(verbose){ std::cout<<"shifting nulls to stores"<<std::endl; }
 				// transfer current contents to Store
-				if(thenulls.size() && thestores.size()){
+				if(thenulls.size() && theindex>0){
 					// sanity check: shouldn't ever happen
-					std::cerr<<"parsing error; transferring nulls into non-empty stores!"<<std::endl;
+					std::cerr<<"parsing error; transferring nulls into non-empty store!"<<std::endl;
 					return false;
 				}
-				thestores.resize(thenulls.size(), BStore(false, false));
 				for(int i=0; i<thenulls.size(); ++i){
 					std::string emptystring="";
-					thestores.at(i).Set(std::to_string(i), emptystring);
+					thestore.Set(std::to_string(i), emptystring);
 				}
+				theindex=thenulls.size();
 				thenulls.clear();
 				all_nulls = false;
 				all_stores = true;
@@ -523,15 +527,15 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 				// doesn't look like a json string. need to use stores
 				if(verbose){ std::cout<<"shifting strings to stores"<<std::endl; }
 				// transfer current contents to Stores
-				if(thestrings.size() && thestores.size()){
+				if(thestrings.size() && theindex>0){
 					// sanity check: shouldn't ever happen
-					std::cerr<<"parsing error; transferring nulls into non-empty stores!"<<std::endl;
+					std::cerr<<"parsing error; transferring nulls into non-empty store!"<<std::endl;
 					return false;
 				}
-				thestores.resize(thestrings.size(), BStore(false, false));
 				for(int i=0; i<thestrings.size(); ++i){
-					thestores.at(i).Set("0",thestrings.at(i));
+					thestore.Set(std::to_string(i),thestrings.at(i));
 				}
+				theindex=thestrings.size();
 				thestrings.clear();
 				all_strings = false;
 				all_stores = true;
@@ -539,13 +543,13 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 		}
 		if(all_stores){
 			if(verbose) std::cout<<"falling back to store"<<std::endl;
-			// build a BStore to encapsulate this element,
-			// but note that it's not an object or array, so we're just gonna
-			// have to make a BStore entry of the correct primitive type
-			thestores.resize(thestores.size()+1,BStore(false, false));
-			bool ok = ScanJsonObjectPrimitive(tmp, thestores.back());
+			// we already checked that this key is not an object or array
+			// before moving on to all_uints, all_sints, etc etc
+			// so we just need to put this primitive into a BStore entry:
+			bool ok = ScanJsonPrimitive(tmp, std::to_string(theindex), thestore);
 			if(verbose) std::cout<<"returned "<<ok<<std::endl;
 			if(!ok) return false;
+			++theindex;
 			continue;
 		}
 		// shouldn't get here
@@ -562,21 +566,33 @@ bool JSONP::ScanJsonArray(const std::string& thejson, JsonParserResult& result){
 	if(thestrings.size()){ result.type = JsonParserResultType::strings; ++typesset; }
 	if(thebools.size())  { result.type = JsonParserResultType::bools;   ++typesset; }
 	if(thenulls.size())  { result.type = JsonParserResultType::nulls;   ++typesset; }
-	if(thestores.size()) { result.type = JsonParserResultType::stores;  ++typesset; }
+	if(theindex>0)       { result.type = JsonParserResultType::stores;  ++typesset; }
 	if(typesset!=1){
-		std::cerr<<"multiple types in return from ScanJsonArray!"<<std::endl;
+		std::cerr<<"multiple ("<<typesset<<") types in return from ScanJsonArray!"<<std::endl;
+		std::cerr<<"for json '"<<thejson<<"', types:"
+			 <<"uints:"<<theuints.size()
+			 <<"sints:"<<thesints.size()
+			 <<"floats:"<<thefloats.size()
+			 <<"strings:"<<thestrings.size()
+			 <<"bools:"<<thebools.size()
+			 <<"nulls:"<<thenulls.size()
+			 <<"store:"<<theindex
+			 <<std::endl;
 		return false;
 	}
+	// one last thing; if we used a store, put the number of elements in it.
+	if(theindex) thestore.Set("#",theindex);
+	// TODO make PR to add a 'Count' method to BStore
 	return true;
 	
 }
 
-bool JSONP::ScanJsonObjectPrimitive(std::string thejson, BStore& outstore){
-	if(verbose) std::cout<<"ScanJsonObjectPrimitive scanning '"<<thejson<<"'"<<std::endl;
+bool JSONP::ScanJsonPrimitive(std::string thejson, std::string thekey, BStore& outstore){
+	if(verbose) std::cout<<"ScanJsonPrimitive scanning '"<<thejson<<"'"<<std::endl;
 	thejson=Trim(thejson);
 	
 	if(thejson.front()=='{' || thejson.front()=='['){
-		std::cerr<<"Warning! ScanJsonObjectPrimitive called with object or array!"<<std::endl;
+		std::cerr<<"Warning! ScanJsonPrimitive called with object or array!"<<std::endl;
 		return false;
 	}
 	
@@ -591,13 +607,13 @@ bool JSONP::ScanJsonObjectPrimitive(std::string thejson, BStore& outstore){
 			// if negative use temporary int64_t
 			int64_t nextint = std::stoll(thejson,&endpos);
 			if(endpos!=thejson.length()) throw std::invalid_argument("extra chars");
-			outstore.Set("0",nextint);
+			outstore.Set(thekey,nextint);
 			return true;
 		} else {
 			// else use temporary uint64_t
 			uint64_t nextint = std::stoull(thejson,&endpos);
 			if(endpos!=thejson.length()) throw std::invalid_argument("extra chars");
-			outstore.Set("0",nextint);
+			outstore.Set(thekey,nextint);
 			return true;
 		}
 	}
@@ -610,7 +626,7 @@ bool JSONP::ScanJsonObjectPrimitive(std::string thejson, BStore& outstore){
 		size_t endpos=0;
 		double nextfloat = std::stod(thejson,&endpos);
 		if(endpos!=thejson.length()) throw std::invalid_argument("extra chars");
-		outstore.Set("0",nextfloat);
+		outstore.Set(thekey,nextfloat);
 		return true;
 	}
 	catch(std::invalid_argument& e){
@@ -621,30 +637,30 @@ bool JSONP::ScanJsonObjectPrimitive(std::string thejson, BStore& outstore){
 	if(iEquals(thejson,"TRUE")){
 		bool val=true;
 		if(verbose) std::cout<<"match bool"<<std::endl;
-		outstore.Set("0",val);
+		outstore.Set(thekey,val);
 		return true;
 	}
 	if(iEquals(thejson,"FALSE")){
 		if(verbose) std::cout<<"match bool"<<std::endl;
 		bool val=false;
-		outstore.Set("0",val);
+		outstore.Set(thekey,val);
 		return true;
 	}
 	if(verbose) std::cout<<"try null"<<std::endl;
 	if(iEquals(thejson,"null")){
 		if(verbose) std::cout<<"match null"<<std::endl;
 		std::string val="";
-		outstore.Set("0",val);
+		outstore.Set(thekey,val);
 		return true;
 	}
 	if(verbose) std::cout<<"try string"<<std::endl;
 	if(thejson.length()>1 && thejson.front()=='"' && thejson.back()=='"'){
 		if(verbose) std::cout<<"match string"<<std::endl;
 		std::string substr = thejson.substr(1,thejson.length()-2);
-		outstore.Set("0",substr);
+		outstore.Set(thekey,substr);
 		return true;
 	}
-	std::cerr<<"No handler for string "<<thejson<<" in ScanJsonObjectPrimitive!"<<std::endl;
+	std::cerr<<"No handler for string "<<thejson<<" in ScanJsonPrimitive!"<<std::endl;
 	
 	return false;
 	
@@ -757,8 +773,8 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 			// if not processing a key, parse the value
 			bool trytoparse=true;
 			if(trytoparse && tmp.front()=='{'){
-				// add the new element
-				BStore res(false, false);
+				// it's an object, recursively parse it
+				BStore res(false,typechecking);
 				bool ok =  ScanJsonObject(tmp.substr(1,tmp.length()-2), res);
 				if(!ok) return false;
 				outstore.Set(next_key,res);
@@ -767,11 +783,12 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 			if(verbose && trytoparse) std::cout<<"not object"<<std::endl;
 			if(trytoparse && tmp.front()=='['){
 				if(verbose) std::cout<<"it array"<<std::endl;
-				// add the new element
-				JsonParserResult res;
+				// it's an array, call ScanJsonArray to parse it to something suitable
+				JsonParserResult res(typechecking);
 				bool ok =  ScanJsonArray(tmp.substr(1,tmp.length()-2), res);
 				if(verbose) std::cout<<"parse array ret:"<<ok<<std::endl;
 				if(!ok || res.type==JsonParserResultType::undefined) return false;
+				// add to the store depending on the type ScanJsonArray found it to be
 				switch (res.type){
 					case JsonParserResultType::sints: {
 						if(verbose) std::cout<<"array was of signed ints"<<std::endl;
@@ -804,8 +821,8 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 						break;
 					}
 					case JsonParserResultType::stores: {
-						if(verbose) std::cout<<"array was of stores"<<std::endl;
-						outstore.Set(next_key,res.thestores);
+						if(verbose) std::cout<<"array was of inhomogeneous type (convered to BStore)"<<std::endl;
+						outstore.Set(next_key,res.thestore);
 						break;
 					}
 					case JsonParserResultType::empty: {
@@ -824,18 +841,19 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 			if(verbose && trytoparse) std::cout<<"not array"<<std::endl;
 			
 			if(trytoparse){
-				// discard leading whitespace
+				// try int
+				// first discard leading whitespace
 				size_t startpos=0;
 				size_t endpos=0;
 				while(startpos<tmp.length() && std::isspace(tmp[startpos])) ++startpos;
 				try {
 					if(tmp.front()=='-'){
-						// if negative use temporary int64_t
+						// if negative try temporary int64_t
 						int64_t nextint = std::stoll(tmp,&endpos);
 						if(endpos!=tmp.length()) throw std::invalid_argument("extra chars");
 						outstore.Set(next_key,nextint);
 					} else {
-						// else use temporary uint64_t
+						// else try temporary uint64_t
 						uint64_t nextint = std::stoull(tmp,&endpos);
 						if(endpos!=tmp.length()) throw std::invalid_argument("extra chars");
 						outstore.Set(next_key,nextint);
@@ -848,6 +866,7 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 			}
 			if(verbose && trytoparse) std::cout<<"not int"<<std::endl;
 			if(trytoparse){
+				// try double
 				try {
 					size_t endpos=0;
 					double nextfloat = std::stod(tmp,&endpos);
@@ -861,6 +880,7 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 			}
 			if(verbose && trytoparse) std::cout<<"not float"<<std::endl;
 			if(trytoparse){
+				// try bool
 				if(iEquals(tmp,"TRUE")){
 					bool val=true;
 					outstore.Set(next_key,val);
@@ -873,6 +893,7 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 			}
 			if(verbose && trytoparse) std::cout<<"not bool"<<std::endl;
 			if(trytoparse){
+				// try null
 				if(iEquals(tmp,"null")){
 					std::string nullstring;
 					outstore.Set(next_key,nullstring);
@@ -881,6 +902,7 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 			}
 			if(verbose && trytoparse) std::cout<<"not null"<<std::endl;
 			if(trytoparse){
+				// try string
 				if(tmp.length()>1 && tmp.front()=='"' && tmp.back()=='"'){
 					std::string substr = tmp.substr(1,tmp.length()-2);
 					outstore.Set(next_key,substr);
@@ -889,10 +911,11 @@ bool JSONP::ScanJsonObject(std::string thejson, BStore& outstore){
 			}
 			if(verbose && trytoparse) std::cout<<"not string"<<std::endl;
 			if(trytoparse){
-				BStore astore(false, false);
-				bool ok = ScanJsonObjectPrimitive(tmp, astore);
+				// try... primitive?
+				// is this just a factored-out duplicate of all the above lines?
+				BStore astore(false,typechecking);
+				bool ok = ScanJsonPrimitive(tmp, next_key, astore);
 				if(!ok) return false;
-				outstore.Set(next_key,astore);
 				trytoparse=false;
 			}
 			if(trytoparse){

--- a/JsonParser.h
+++ b/JsonParser.h
@@ -16,10 +16,10 @@ struct JsonParserResult {
 	std::vector<std::string> thestrings{};
 	std::vector<int> thebools{};
 	std::vector<std::string> thenulls{};
-	std::vector<BStore> thestores{};
+	BStore thestore;
 	JsonParserResultType type=JsonParserResultType::undefined;
 	
-	JsonParserResult() {};
+	JsonParserResult(bool typechecking) { thestore=BStore(false,typechecking); };
 };
 
 class JSONP {
@@ -27,11 +27,6 @@ class JSONP {
 	JSONP(){};
 	~JSONP(){};
 	
-	// NOTE: output BStore should have typechecking DISABLED as the specific types used
-	// may not be guaranteed! (i.e. what specific type of integer is {"anum":5}? uint32_t? int64_t?)
-	// specifically all integers will be uint64_t unless negative, then int64_t.
-	// all non-integral numbers will be double.)
-	// however the typechecking propagation previously was not complete and would change during parsing...
 	bool Parse(std::string thejson, BStore& output);
 	std::string Trim(const std::string& thejson);
 	bool iEquals(const std::string& str1, const std::string& str2);
@@ -39,9 +34,11 @@ class JSONP {
 	
 	private:
 	bool ScanJsonArray(const std::string& thejson, JsonParserResult& result);
-	bool ScanJsonObjectPrimitive(std::string thejson, BStore& outstore);
+	bool ScanJsonPrimitive(std::string thejson, std::string thekey, BStore& outstore);
 	bool ScanJsonObject(std::string thejson, BStore& outstore);
+	
 	int verbose=0;
+	bool typechecking=false;
 	
 };
 #endif

--- a/JsonParser.h
+++ b/JsonParser.h
@@ -8,18 +8,18 @@
 
 using namespace ToolFramework; // for BStore
 
-enum class JsonParserResultType { ints, floats, strings, bools, nulls, stores, empty, undefined };
+enum class JsonParserResultType { sints, uints, floats, strings, bools, nulls, stores, empty, undefined };
 struct JsonParserResult {
-	std::vector<int64_t> theints{};
+	std::vector<int64_t> thesints{};
+	std::vector<uint64_t> theuints{};
 	std::vector<double> thefloats{};
 	std::vector<std::string> thestrings{};
 	std::vector<int> thebools{};
 	std::vector<std::string> thenulls{};
 	std::vector<BStore> thestores{};
 	JsonParserResultType type=JsonParserResultType::undefined;
-	bool typechecking;
 	
-	JsonParserResult(bool typechecking): typechecking(typechecking) {};
+	JsonParserResult() {};
 };
 
 class JSONP {
@@ -27,6 +27,11 @@ class JSONP {
 	JSONP(){};
 	~JSONP(){};
 	
+	// NOTE: output BStore should have typechecking DISABLED as the specific types used
+	// may not be guaranteed! (i.e. what specific type of integer is {"anum":5}? uint32_t? int64_t?)
+	// specifically all integers will be uint64_t unless negative, then int64_t.
+	// all non-integral numbers will be double.)
+	// however the typechecking propagation previously was not complete and would change during parsing...
 	bool Parse(std::string thejson, BStore& output);
 	std::string Trim(const std::string& thejson);
 	bool iEquals(const std::string& str1, const std::string& str2);

--- a/JsonParser.h
+++ b/JsonParser.h
@@ -30,6 +30,7 @@ class JSONP {
 	bool Parse(std::string thejson, BStore& output);
 	std::string Trim(const std::string& thejson);
 	bool iEquals(const std::string& str1, const std::string& str2);
+	bool IsInteger(std::string& tmp);
 	void SetVerbose(bool);
 	
 	private:

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ all: middleman
 middleman: main.cpp $(filter-out main.o, $(patsubst %.cpp, %.o, $(wildcard *.cpp)))
 	g++ $(CXXFLAGS) $^ -o $@ -I./ $(PostgresInclude) $(BoostInclude) $(PostgresLib) $(ZMQInclude) $(BoostLib) $(ZMQLib) $(ToolFrameworkLib) $(ToolFrameworkInclude) $(ToolDAQFrameworkLib) $(ToolDAQFrameworkInclude) -lpthread
 
+testparse: testparse.cxx $(filter-out main.o, $(patsubst %.cpp, %.o, $(wildcard *.cpp)))
+	g++ $(CXXFLAGS) $^ -o $@ -I./ $(PostgresInclude) $(BoostInclude) $(PostgresLib) $(ZMQInclude) $(BoostLib) $(ZMQLib) $(ToolFrameworkLib) $(ToolFrameworkInclude) $(ToolDAQFrameworkLib) $(ToolDAQFrameworkInclude) -lpthread
+
 %.o: %.cpp %.h
 	g++ $(CXXFLAGS) -c -fPIC $< -o $@ -I./ $(PostgresInclude) $(BoostInclude) $(PostgresLib) $(ZMQInclude) $(BoostLib) $(ZMQLib) $(ToolFrameworkLib) $(ToolFrameworkInclude) $(ToolDAQFrameworkLib) $(ToolDAQFrameworkInclude) -lpthread
 

--- a/ReceiveSQL.cpp
+++ b/ReceiveSQL.cpp
@@ -19,6 +19,7 @@
 //                   ≫ ──── ≪•◦ ❈ ◦•≫ ──── ≪
 
 bool ReceiveSQL::Initialise(const std::string& configfile){
+	//parser.SetVerbose(true);
 	Store m_variables;
 	Log("Reading config",3);
 	m_variables.Initialise(configfile);
@@ -1156,7 +1157,7 @@ bool ReceiveSQL::WritePlotlyPlotToQuery(const std::string& message, BStore& plot
 	std::string traces;
 	std::string layout;
 	int version = -1;
-	int64_t timestamp = 0;
+	uint64_t timestamp = 0;
 	get_ok  = plot.Get("name", name);
 	get_ok &= plot.JsonEncode("traces", traces);
 	get_ok &= plot.JsonEncode("layout", layout);
@@ -1200,7 +1201,7 @@ bool ReceiveSQL::WriteMessageToQuery(const std::string& topic, const std::string
 	Log(Concat("Forming SQL for write query with topic: '",topic,"', message: '",message,"'"),4);
 
 	// write queries received on the pub port are JSON messages that we need to convert to SQL.
-	BStore store(false, true);
+	BStore store(false, false); // must disable typechecking
 	get_ok = parser.Parse(message, store);
 	if(!get_ok){
 		Log("WriteMessageToQuery error parsing message json '"+message+"'",v_error);

--- a/ReceiveSQL.cpp
+++ b/ReceiveSQL.cpp
@@ -1058,7 +1058,7 @@ bool ReceiveSQL::WriteAlarmToQuery(const std::string& message, BStore& alarm, st
 	//time_t timestamp{0};
 	uint64_t timestamp{0};
 	std::string device;
-	uint32_t level;
+	uint64_t level;
 	std::string msg;
 	alarm.Get("time",timestamp);  // may not be present, in which case use 0 -> i.e. now()
 	get_ok  = alarm.Get("device",device);
@@ -1156,8 +1156,8 @@ bool ReceiveSQL::WritePlotlyPlotToQuery(const std::string& message, BStore& plot
 	std::string name;
 	std::string traces;
 	std::string layout;
-	int version = -1;
 	uint64_t timestamp = 0;
+	uint64_t version = -1;
 	get_ok  = plot.Get("name", name);
 	get_ok &= plot.JsonEncode("traces", traces);
 	get_ok &= plot.JsonEncode("layout", layout);
@@ -1201,7 +1201,11 @@ bool ReceiveSQL::WriteMessageToQuery(const std::string& topic, const std::string
 	Log(Concat("Forming SQL for write query with topic: '",topic,"', message: '",message,"'"),4);
 
 	// write queries received on the pub port are JSON messages that we need to convert to SQL.
-	BStore store(false, false); // must disable typechecking
+	BStore store(false, true); // WritePlotlyPlotToQuery requires BStore::JsonEncoder, which requires typechecking
+	// since the JsonParser/JSONP class needs to convert string numbers to c++ integral types, the best way seems to be:
+	// convert all integral numbers to uint64_t (typechecking then requires we also extract as uint64_t)
+	// if the value may have been negative, use `int64_t val = *reinterpret_cast<int64_t*>(&uint64_val);` to convert it.
+	// this process should support all positive and negative integral numbers. (floating point numbers are all doubles).
 	get_ok = parser.Parse(message, store);
 	if(!get_ok){
 		Log("WriteMessageToQuery error parsing message json '"+message+"'",v_error);
@@ -1340,13 +1344,14 @@ bool ReceiveSQL::ReadDeviceConfigToQuery(const std::string& message, BStore& req
 	
 	// get a new device config entry
 	std::string device;
-	int32_t version;
+	uint64_t version_u;
 	get_ok  = request.Get("device",device);
-	get_ok &= request.Get("version",version);
+	get_ok &= request.Get("version",version_u);
 	if(!get_ok){
-		return false;
 		Log("ReadDeviceConfigToQuery missing fields in message '"+message+"'",v_error);
+		return false;
 	}
+	int version = *reinterpret_cast<int64_t*>(&version_u);
 	
 	// SQL sanitization
 	get_ok  = a_database.pqxx_quote(device, device);
@@ -1383,9 +1388,10 @@ bool ReceiveSQL::ReadRunConfigToQuery(const std::string& message, BStore& reques
 	// it would seem sensible that users may query via a specific 'config_id'
 	// or via a pair of 'name' and 'version'
 	// first check for a specific config_id
-	int32_t config_id;
-	get_ok  = request.Get("config_id",config_id);
+	uint64_t config_id_u;
+	get_ok  = request.Get("config_id",config_id_u);
 	if(get_ok){
+		int config_id = *reinterpret_cast<int64_t*>(&config_id_u);
 		// if user requests id <0, give latest
 		std::string idstring;
 		if(config_id<0){
@@ -1400,12 +1406,12 @@ bool ReceiveSQL::ReadRunConfigToQuery(const std::string& message, BStore& reques
 		
 		// if not given, see if there is a name and version number
 		std::string config_name;
-		int32_t version_num;
+		uint64_t version_u;
 		get_ok = request.Get("name",config_name);
-		get_ok = get_ok && request.Get("version",version_num);
+		get_ok = get_ok && request.Get("version",version_u);
 		if(!get_ok){
-			return false;
 			Log("ReadRunConfigToQuery missing fields in message '"+message+"'",v_error);
+			return false;
 		}
 		
 		// SQL sanitization
@@ -1416,6 +1422,7 @@ bool ReceiveSQL::ReadRunConfigToQuery(const std::string& message, BStore& reques
 		}
 		
 		// if user requests version <0, give latest
+		int version_num = *reinterpret_cast<int64_t*>(&version_u);
 		std::string versionstring;
 		if(version_num<0){
 			versionstring = "(SELECT MAX(version) FROM configurations WHERE name="+config_name+")";
@@ -1441,9 +1448,9 @@ bool ReceiveSQL::ReadCalibrationToQuery(const std::string& message, BStore& requ
 	
 	// get a calibration data entry
 	std::string device;
-	int32_t version;
+	uint64_t version_u;
 	get_ok  = request.Get("device",device);
-	get_ok &= request.Get("version",version);
+	get_ok &= request.Get("version",version_u);
 	if(!get_ok){
 		Log("ReadCalibrationToQuery missing fields in message '"+message+"'",v_error);
 		return false;
@@ -1457,6 +1464,7 @@ bool ReceiveSQL::ReadCalibrationToQuery(const std::string& message, BStore& requ
 	}
 	
 	// if user requests version <0, give latest
+	int version = *reinterpret_cast<int64_t*>(&version_u);
 	std::string versionstring;
 	if(version<0){
 		versionstring = "(SELECT MAX(version) FROM device_config WHERE device="+device+")";
@@ -1482,9 +1490,9 @@ bool ReceiveSQL::ReadRootPlotToQuery(const std::string& message, BStore& request
 	
 	// get a ROOT plot entry
 	std::string plot_name;
-	int version=-1;
+	uint64_t version_u = -1;
 	get_ok  = request.Get("plot_name",plot_name);
-	get_ok &= request.Get("version",version);
+	request.Get("version",version_u);
 	if(!get_ok){
 		Log("ReadRootPlotToQuery missing fields in message '"+message+"'",v_error);
 		return false;
@@ -1499,6 +1507,7 @@ bool ReceiveSQL::ReadRootPlotToQuery(const std::string& message, BStore& request
 	
 	// FIXME this needs to know which rootplots table to read from
 	sql_out = "SELECT draw_options, time, version, data FROM rootplots WHERE name=" + plot_name;
+	int version = *reinterpret_cast<int64_t*>(&version_u);
 	if(version<0){
 		sql_out += " ORDER BY time DESC LIMIT 1;";
 	} else {
@@ -1518,9 +1527,9 @@ bool ReceiveSQL::ReadPlotlyPlotToQuery(const std::string& message, BStore& reque
 	Postgres& a_database = m_databases.at(db_out);
 
 	std::string name;
-	int version = -1;
+	uint64_t version_u = -1;
 	get_ok = request.Get("name", name);
-	request.Get("version", version);
+	request.Get("version", version_u);
 	if (!get_ok) {
 		Log("ReadPlotlyPlotToQuery: missing fields in message '" + message + "'", v_error);
 		return false;
@@ -1534,6 +1543,7 @@ bool ReceiveSQL::ReadPlotlyPlotToQuery(const std::string& message, BStore& reque
 	}
 
 	sql_out = "SELECT version, traces, layout, time FROM plotlyplots WHERE name = " + name;
+	int version = *reinterpret_cast<int64_t*>(&version_u);
 	if (version < 0) {
 		sql_out += " ORDER BY time DESC LIMIT 1;";
 	} else {
@@ -1664,7 +1674,7 @@ bool ReceiveSQL::MulticastMessageToQuery(const std::string& message, std::string
 		std::string device;
 		//time_t timestamp{0};
 		uint64_t timestamp{0};
-		uint32_t severity;
+		uint64_t severity;
 		std::string msg;
 		get_ok = tmp.Get("time",timestamp); // optional
 		get_ok = tmp.Get("device",device);

--- a/testparse.cxx
+++ b/testparse.cxx
@@ -1,0 +1,76 @@
+#include "JsonParser.h"
+#include <iostream>
+#include <string>
+
+int main(){
+	JSONP parser;
+	//parser.SetVerbose(1);
+	std::string testjson="{ \"device\":\"mydevice\", \"signed\":-12, \"unsigned\":3, \"zero\":0, \"trailingspace\":  999 , "
+                             "  \"unsigneds\":[10,11,12], \"signeds\":[-12,13,-15], \"floats\":[12.2,13.3,14.4], \"signeds2\":[10,-11,12], "
+                             "\"floats2\":[10,-12,13.33],\"cat?\":\"yes\" }";
+	BStore out(false,false);
+	parser.Parse(testjson, out);
+	
+	// notes as of time of writing (29-jan-2025):
+	// BStore::Print(true) doesn't work as internals are binary and can't be printed
+	// BStore::operator>> doesn't work as it needs updating to properly outupt valid JSON
+	
+	std::string device;
+	int64_t asigned;
+	uint64_t aunsigned;
+	int64_t azero;
+	int64_t trailing;
+	std::vector<int64_t> signs;
+	std::vector<int64_t> unsigns;
+	std::vector<int64_t> signs2;
+	std::vector<double> floats;
+	std::vector<double> floats2;
+	
+	bool ok;
+	ok = out.Get("device",device);
+	ok = out.Get("signed",asigned);
+	ok = out.Get("unsigned",aunsigned);
+	ok = out.Get("zero",azero);
+	ok = out.Get("trailingspace",trailing);
+	out.Get("signeds",signs);
+	out.Get("unsigneds",unsigns);
+	out.Get("signeds2",signs2);
+	out.Get("floats",floats);
+	out.Get("floats2",floats2);
+	
+	std::cout<<"device: "<<device
+		<<", signed: "<<asigned
+		<<", unsigned: "<<aunsigned
+		<<", zero: "<<azero
+		<<", trailingspace: "<<trailing
+		<<std::endl;
+	std::cout<<"signeds:"<<std::endl;
+	for(auto& asigned : signs){
+		std::cout<<asigned<<", ";
+	}
+	std::cout<<std::endl;
+	std::cout<<"unsigneds:"<<std::endl;
+	for(auto& ausigned : unsigns){
+		std::cout<<ausigned<<", ";
+	}
+	std::cout<<std::endl;
+	std::cout<<"floats:"<<std::endl;
+	for(auto& afloat : floats){
+		std::cout<<afloat<<", ";
+	}
+	std::cout<<std::endl;
+	std::cout<<"signeds2:"<<std::endl;
+	for(auto& asigned : signs2){
+		std::cout<<asigned<<", ";
+	}
+	std::cout<<std::endl;
+	std::cout<<"floats2:"<<std::endl;
+	for(auto& afloat : floats2){
+		std::cout<<afloat<<", ";
+	}
+	
+	
+	
+	return 0;
+}
+

--- a/testparse.cxx
+++ b/testparse.cxx
@@ -4,11 +4,30 @@
 
 int main(){
 	JSONP parser;
+	
 	//parser.SetVerbose(1);
 	std::string testjson="{ \"device\":\"mydevice\", \"signed\":-12, \"unsigned\":3, \"zero\":0, \"trailingspace\":  999 , "
                              "  \"unsigneds\":[10,11,12], \"signeds\":[-12,13,-15], \"floats\":[12.2,13.3,14.4], \"signeds2\":[10,-11,12], "
-                             "\"floats2\":[10,-12,13.33],\"cat?\":\"yes\" }";
-	BStore out(false,false);
+                             "\"floats2\":[10,-12,13.33],\"cat?\":\"yes\", \"inhomo\":[ 5, true, \"cat\" ], "
+	                     "  \"nested\":[ { \"inner1\":\"1\", \"inner2\":\"2\" }, { \"inner3\":\"3\", \"inner4\":\"4\" } ], "
+	                     " \"nested2\":[ [ 1,2,3 ], [4,5,6] ] }";
+	
+        // NOTE:
+        // what specific type of integer is {"anum":5}? uint32_t? int64_t?
+        // to prevent truncation we assume longs, but we need to use strol or stroul
+        // depending on sign or unsigned to prevent possible invalid value (truncation or sign misinterpretation)
+        // so we check numeric string for leading '-' and all negative integers will be int64_t, all positive integers uint64_t.
+        // (for arrays, if any number is negative all are treated as signed, otherwise all unsigned.)
+        // (all non-integral numbers will be double.)
+        // However if typechecking is enabled this means you need to know if your numeric is + or -
+        // to know the right type with which to Get it from the BStore, and that might be problematic if sign fluctuates.
+        // So we turn typechecking off by default....
+        // But then if we have JSON [ 5, true, null ], this goes into a BStore, and now the user needs to know
+        // the types of every element in order to get them all appropriately...and that's a pain for a test script that
+	// just wants to print them out.
+        // so we use Evgenii's handy JsonEncode, but that requires typechecking on, so we turn it on just for testing.
+	bool typechecking=false;
+	BStore out(false,typechecking);
 	parser.Parse(testjson, out);
 	
 	// notes as of time of writing (29-jan-2025):
@@ -16,8 +35,10 @@ int main(){
 	// BStore::operator>> doesn't work as it needs updating to properly outupt valid JSON
 	
 	std::string device;
-	int64_t asigned;
-	uint64_t aunsigned;
+	//int64_t asigned;
+	//uint64_t aunsigned;
+	int32_t asigned;
+	int32_t aunsigned;
 	int64_t azero;
 	int64_t trailing;
 	std::vector<int64_t> signs;
@@ -25,6 +46,9 @@ int main(){
 	std::vector<int64_t> signs2;
 	std::vector<double> floats;
 	std::vector<double> floats2;
+	BStore arraystore(false,typechecking);
+	BStore nestedobjs(false,typechecking);
+	BStore nestedarrays(false,typechecking);
 	
 	bool ok;
 	ok = out.Get("device",device);
@@ -37,6 +61,9 @@ int main(){
 	out.Get("signeds2",signs2);
 	out.Get("floats",floats);
 	out.Get("floats2",floats2);
+	ok = out.Get("inhomo",arraystore);
+	ok = out.Get("nested",nestedobjs);
+	ok = out.Get("nested2",nestedarrays);
 	
 	std::cout<<"device: "<<device
 		<<", signed: "<<asigned
@@ -68,8 +95,65 @@ int main(){
 	for(auto& afloat : floats2){
 		std::cout<<afloat<<", ";
 	}
+	std::cout<<std::endl;
 	
+	std::cout<<"inhomo:"<<std::endl;
+	int arraystoresize=0;
+	ok = arraystore.Get("#",arraystoresize);
+	std::cout<<"size: "<<arraystoresize<<std::endl;
+	// bit of a stuck situation here though:
+	// how do we know what the type of each element is?
+	// JsonEncode to the rescue!
+	for(int i=0; i<arraystoresize; ++i){
+		std::string tmp;
+		arraystore.JsonEncode(std::to_string(i),tmp);
+		std::cout<<'\t'<<i<<": "<<tmp<<std::endl;
+	}
 	
+	std::cout<<"nested:"<<std::endl;
+	arraystoresize=0;
+	nestedobjs.Get("#",arraystoresize);
+	std::cout<<"size: "<<arraystoresize<<std::endl;
+	for(int i=0; i<arraystoresize; ++i){
+		BStore inner(false,true);
+		nestedobjs.Get(std::to_string(i),inner);
+		std::cout<<i<<":"<<std::endl;
+		inner.Print(true);
+	}
+
+
+	std::cout<<"nested2:"<<std::endl;
+	//nestedarrays.Print();
+	arraystoresize=0;
+	nestedarrays.Get("#",arraystoresize);
+	std::cout<<"size: "<<arraystoresize<<std::endl;
+	int elcount=0;
+	for(int i=0; i<arraystoresize; ++i){
+		
+		std::vector<uint64_t> tmpvec;
+		nestedarrays.Get(std::to_string(i),tmpvec);
+		std::cout<<i<<": [";
+		for(uint64_t& aval : tmpvec) std::cout<<aval<<"; ";
+		std::cout<<"]"<<std::endl;
+		
+		/*
+		BStore inner(false,true);
+		nestedarrays.Get(std::to_string(i),inner);
+		
+		int innersize=0;
+		inner.Get("#",innersize);
+		std::cout<<"inner "<<i<<" of size "<<innersize<<std::endl;
+		for(int j=0; j<innersize; ++j){
+			std::string innerkey = std::string{"inner"}+std::to_string(elcount);
+			innerval=0;
+			inner.Get(innerkey,innerval);
+			std::cout<<"\t\t"<<innerkey<<":"<<innerval<<std::endl;
+			++elcount;
+		}
+		*/
+	}
+	
+	std::cout<<"done"<<std::endl;
 	
 	return 0;
 }

--- a/testparse.cxx
+++ b/testparse.cxx
@@ -1,9 +1,13 @@
 #include "JsonParser.h"
 #include <iostream>
 #include <string>
+#include <limits>
 
 int main(){
 	JSONP parser;
+	bool ok;
+	bool typechecking=true;
+	BStore out(false,typechecking);  // BStore::BStore(header, typechecking)
 	
 	//parser.SetVerbose(1);
 	std::string testjson="{ \"device\":\"mydevice\", \"signed\":-12, \"unsigned\":3, \"zero\":0, \"trailingspace\":  999 , "
@@ -11,6 +15,12 @@ int main(){
                              "\"floats2\":[10,-12,13.33],\"cat?\":\"yes\", \"inhomo\":[ 5, true, \"cat\" ], "
 	                     "  \"nested\":[ { \"inner1\":\"1\", \"inner2\":\"2\" }, { \"inner3\":\"3\", \"inner4\":\"4\" } ], "
 	                     " \"nested2\":[ [ 1,2,3 ], [4,5,6] ] }";
+	//std::string testjson="{ \"uintmax\":" + std::to_string(std::numeric_limits<uint64_t>::max())
+                             +", \"intmax\":" + std::to_string(std::numeric_limits<int64_t>::max())
+	                    +", \"intmin\":" + std::to_string(std::numeric_limits<int64_t>::min())+" }";
+	
+	std::cout<<"testjson: "<<testjson<<std::endl;
+	parser.Parse(testjson, out);
 	
         // NOTE:
         // what specific type of integer is {"anum":5}? uint32_t? int64_t?
@@ -26,9 +36,40 @@ int main(){
         // the types of every element in order to get them all appropriately...and that's a pain for a test script that
 	// just wants to print them out.
         // so we use Evgenii's handy JsonEncode, but that requires typechecking on, so we turn it on just for testing.
-	bool typechecking=false;
-	BStore out(false,typechecking);
-	parser.Parse(testjson, out);
+	
+	/*
+	uint64_t a=0,b=0,c=0;
+	ok = out.Get("uintmax",a);
+	std::cout<<"OK:"<<ok<<std::endl;
+	ok = out.Get("intmax",b);
+	std::cout<<"OK:"<<ok<<std::endl;
+	ok = out.Get("intmin",c);
+	std::cout<<"OK:"<<ok<<std::endl;
+	std::cout<<"nums: "<<a<<", "<<*(reinterpret_cast<int64_t*>(&b))<<", "<<*(reinterpret_cast<int64_t*>(&c))<<std::endl;
+	return 0;
+	
+	//////////
+	
+	int64_t signednum;
+	uint64_t unsignednum;
+	
+	out.Get("uintmax",unsignednum);
+	std::cout<<"uint64_t max: "<<unsignednum<<", cast to int64_t: "<<*(reinterpret_cast<int64_t*>(&unsignednum))<<std::endl;
+	out.Get("intmax",signednum);
+	std::cout<<"int64_t max: "<<signednum<<", cast to uint64_t: "<<*(reinterpret_cast<uint64_t*>(&signednum))<<std::endl;
+	out.Get("intmin",signednum);
+	std::cout<<"int64_t min: "<<signednum<<", cast to uint64_t: "<<*(reinterpret_cast<uint64_t*>(&signednum))<<std::endl;
+	
+	out.Get("uintmax",signednum);
+	std::cout<<"uint64_t max into int64_t: "<<signednum<<", cast to uint64_t: "<<*(reinterpret_cast<uint64_t*>(&signednum))<<std::endl;
+	out.Get("intmax",unsignednum);
+	std::cout<<"int64_t max into uint64_t: "<<unsignednum<<", cast to int64_t: "<<*(reinterpret_cast<int64_t*>(&unsignednum))<<std::endl;
+	out.Get("intmin",unsignednum);
+	std::cout<<"int64_t min into uint64_t: "<<unsignednum<<", cast to int64_t: "<<*(reinterpret_cast<int64_t*>(&unsignednum))<<std::endl;
+	
+	
+	return 0;
+	*/
 	
 	// notes as of time of writing (29-jan-2025):
 	// BStore::Print(true) doesn't work as internals are binary and can't be printed
@@ -37,6 +78,7 @@ int main(){
 	std::string device;
 	//int64_t asigned;
 	//uint64_t aunsigned;
+	/*
 	int32_t asigned;
 	int32_t aunsigned;
 	int64_t azero;
@@ -44,13 +86,20 @@ int main(){
 	std::vector<int64_t> signs;
 	std::vector<int64_t> unsigns;
 	std::vector<int64_t> signs2;
+	*/
+	uint64_t asigned;
+	uint64_t aunsigned;
+	uint64_t azero;
+	uint64_t trailing;
+	std::vector<uint64_t> signs;
+	std::vector<uint64_t> unsigns;
+	std::vector<uint64_t> signs2;
 	std::vector<double> floats;
 	std::vector<double> floats2;
 	BStore arraystore(false,typechecking);
 	BStore nestedobjs(false,typechecking);
 	BStore nestedarrays(false,typechecking);
 	
-	bool ok;
 	ok = out.Get("device",device);
 	ok = out.Get("signed",asigned);
 	ok = out.Get("unsigned",aunsigned);
@@ -66,14 +115,14 @@ int main(){
 	ok = out.Get("nested2",nestedarrays);
 	
 	std::cout<<"device: "<<device
-		<<", signed: "<<asigned
+		<<", signed: "<<*reinterpret_cast<int64_t*>(&asigned)
 		<<", unsigned: "<<aunsigned
 		<<", zero: "<<azero
 		<<", trailingspace: "<<trailing
 		<<std::endl;
 	std::cout<<"signeds:"<<std::endl;
 	for(auto& asigned : signs){
-		std::cout<<asigned<<", ";
+		std::cout<<*reinterpret_cast<int64_t*>(&asigned)<<", ";
 	}
 	std::cout<<std::endl;
 	std::cout<<"unsigneds:"<<std::endl;
@@ -88,7 +137,7 @@ int main(){
 	std::cout<<std::endl;
 	std::cout<<"signeds2:"<<std::endl;
 	for(auto& asigned : signs2){
-		std::cout<<asigned<<", ";
+		std::cout<<*reinterpret_cast<int64_t*>(&asigned)<<", ";
 	}
 	std::cout<<std::endl;
 	std::cout<<"floats2:"<<std::endl;


### PR DESCRIPTION
`WritePlotlyPlotToQuery` uses `BStore::JsonEncode`, which requires typechecking to be enabled on the BStore passed to the json parser.
Since typechecking is now enabled, need to get signed integral values (such as version/config numbers) as unsigned (since that's how they're stored internally) and then cast to signed. Internally storing as unsigned is required to prevent truncation of uint64_t timestamp values.

